### PR TITLE
1.8-RELEASE

### DIFF
--- a/easydata-sample/pom.xml
+++ b/easydata-sample/pom.xml
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>io.github.jitwxs</groupId>
             <artifactId>easydata</artifactId>
-            <version>1.7-RELEASE</version>
+            <version>1.8-RELEASE</version>
         </dependency>
         <dependency>
             <groupId>mysql</groupId>

--- a/easydata/lombok.config
+++ b/easydata/lombok.config
@@ -1,0 +1,2 @@
+config.stopBubbling = true
+lombok.addLombokGeneratedAnnotation = true

--- a/easydata/pom.xml
+++ b/easydata/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.jitwxs</groupId>
     <artifactId>easydata</artifactId>
-    <version>1.7-RELEASE</version>
+    <version>1.8-RELEASE</version>
     <packaging>jar</packaging>
 
     <name>easydata</name>

--- a/easydata/pom.xml
+++ b/easydata/pom.xml
@@ -182,6 +182,26 @@
                     </execution>
                 </executions>
             </plugin>
+            <!-- jacoco -->
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.6</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>generate-code-coverage-report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/easydata/src/main/java/io/github/jitwxs/easydata/common/bean/FieldProperty.java
+++ b/easydata/src/main/java/io/github/jitwxs/easydata/common/bean/FieldProperty.java
@@ -90,13 +90,11 @@ public class FieldProperty {
         final Map<String, FieldProperty> resultMap = new HashMap<>();
 
         for (Field field : ReflectionUtils.getFieldsUpTo(target, Object.class)) {
-            final String fieldName = field.getName();
-
-            // ignore process synthetic
-            if (field.isSynthetic()) {
-                log.info("FieldProperty createByJavaBean ignore field by synthetic: {} in {}", fieldName, target);
+            if (isSkipField(field)) {
                 continue;
             }
+
+            final String fieldName = field.getName();
 
             final PropertyDescriptor descriptor = descriptorMap.get(fieldName);
 
@@ -154,6 +152,10 @@ public class FieldProperty {
 
             final Field field = fieldMap.get(fieldName);
 
+            if (isSkipField(field)) {
+                continue;
+            }
+
             resultMap.put(fieldName, FieldProperty.builder()
                     .name(fieldName)
                     .type(descriptor.getPropertyType())
@@ -199,5 +201,21 @@ public class FieldProperty {
         } else {
             return name;
         }
+    }
+
+    private static boolean isSkipField(final Field field) {
+        final String fieldName = field.getName();
+
+        if ("serialVersionUID".equals(fieldName)) {
+            return true;
+        }
+
+        // ignore process synthetic
+        if (field.isSynthetic()) {
+            log.info("FieldProperty createByJavaBean ignore field by synthetic: {}", fieldName);
+            return true;
+        }
+
+        return false;
     }
 }

--- a/easydata/src/main/java/io/github/jitwxs/easydata/common/bean/FieldProperty.java
+++ b/easydata/src/main/java/io/github/jitwxs/easydata/common/bean/FieldProperty.java
@@ -16,6 +16,7 @@ import java.beans.IntrospectionException;
 import java.beans.Introspector;
 import java.beans.PropertyDescriptor;
 import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -213,6 +214,11 @@ public class FieldProperty {
         // ignore process synthetic
         if (field.isSynthetic()) {
             log.info("FieldProperty createByJavaBean ignore field by synthetic: {}", fieldName);
+            return true;
+        }
+
+        // ignore static field
+        if (Modifier.isStatic(field.getModifiers())) {
             return true;
         }
 

--- a/easydata/src/main/java/io/github/jitwxs/easydata/common/bean/FieldProperty.java
+++ b/easydata/src/main/java/io/github/jitwxs/easydata/common/bean/FieldProperty.java
@@ -9,6 +9,7 @@ import io.github.jitwxs.easydata.common.util.ObjectUtils;
 import io.github.jitwxs.easydata.common.util.ReflectionUtils;
 import lombok.Builder;
 import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
 
 import java.beans.BeanInfo;
 import java.beans.IntrospectionException;
@@ -27,6 +28,7 @@ import java.util.stream.Collectors;
  * @since 2022-05-19 23:32
  */
 @Data
+@Slf4j
 @Builder
 public class FieldProperty {
     /**
@@ -89,6 +91,12 @@ public class FieldProperty {
 
         for (Field field : ReflectionUtils.getFieldsUpTo(target, Object.class)) {
             final String fieldName = field.getName();
+
+            // ignore process synthetic
+            if (field.isSynthetic()) {
+                log.info("FieldProperty createByJavaBean ignore field by synthetic: {} in {}", fieldName, target);
+                continue;
+            }
 
             final PropertyDescriptor descriptor = descriptorMap.get(fieldName);
 

--- a/easydata/src/main/java/io/github/jitwxs/easydata/common/bean/MockConfig.java
+++ b/easydata/src/main/java/io/github/jitwxs/easydata/common/bean/MockConfig.java
@@ -64,7 +64,15 @@ public class MockConfig {
 
     private MockStringEnum stringEnum = MockStringEnum.ENGLISH;
 
+    /**
+     * TypeVariable缓存
+     */
     private final Map<String, Type> typeVariableCache = new HashMap<>();
+
+    /**
+     * Bean缓存
+     */
+    private final Map<String, Object> beanCache = new HashMap<>();
 
     public MockConfig init(Type type) {
         if (type instanceof ParameterizedType) {

--- a/easydata/src/main/java/io/github/jitwxs/easydata/common/cache/EnumCache.java
+++ b/easydata/src/main/java/io/github/jitwxs/easydata/common/cache/EnumCache.java
@@ -1,6 +1,7 @@
 package io.github.jitwxs.easydata.common.cache;
 
 import com.google.protobuf.ProtocolMessageEnum;
+import io.github.jitwxs.easydata.common.util.CollectionUtils;
 import lombok.Getter;
 import org.powermock.reflect.Whitebox;
 
@@ -66,7 +67,7 @@ public class EnumCache {
         }
 
         public Enum random() {
-            return this.idMap.values().iterator().next();
+            return CollectionUtils.randomElement(this.idMap.values());
         }
     }
 }

--- a/easydata/src/main/java/io/github/jitwxs/easydata/common/util/BigDecimalUtils.java
+++ b/easydata/src/main/java/io/github/jitwxs/easydata/common/util/BigDecimalUtils.java
@@ -6,7 +6,7 @@ import java.math.BigDecimal;
  * @author jitwxs@foxmail.com
  * @since 2022-03-27 21:31
  */
-public class BigDecimalUtil {
+public class BigDecimalUtils {
     public static BigDecimal zeroIfNull(BigDecimal val) {
         return val == null ? BigDecimal.ZERO : val;
     }

--- a/easydata/src/main/java/io/github/jitwxs/easydata/common/util/CollectionUtils.java
+++ b/easydata/src/main/java/io/github/jitwxs/easydata/common/util/CollectionUtils.java
@@ -1,0 +1,19 @@
+package io.github.jitwxs.easydata.common.util;
+
+import java.util.Collection;
+import java.util.Iterator;
+
+/**
+ * @author jitwxs@foxmail.com
+ * @since 2022-05-26 22:59
+ */
+public class CollectionUtils {
+    public static <T> T randomElement(Collection<T> c) {
+        int random = (int) (Math.random() * c.size());
+        Iterator<T> it = c.iterator();
+        for (int i = 0; i < random; i++) {
+            it.next();
+        }
+        return it.next();
+    }
+}

--- a/easydata/src/main/java/io/github/jitwxs/easydata/common/util/ObjectUtils.java
+++ b/easydata/src/main/java/io/github/jitwxs/easydata/common/util/ObjectUtils.java
@@ -92,9 +92,10 @@ public class ObjectUtils {
     /**
      * 构造 proto 对象，并填充属性
      *
-     * @param target             proto 对象类型
-     * @param fieldGeneratorFunc 属性生成方法
-     * @param <T>                proto 对象类型
+     * @param target                   proto 对象类型
+     * @param fieldIgnoreGeneratorFunc 属性是否忽略判断
+     * @param fieldGeneratorFunc       属性生成方法
+     * @param <T>                      proto 对象类型
      * @return proto 对象
      * @throws IllegalAccessException    if this {@code Method} object is enforcing Java language access control
      *                                   and the underlying method is inaccessible.

--- a/easydata/src/main/java/io/github/jitwxs/easydata/core/convert/MapEntryConvert.java
+++ b/easydata/src/main/java/io/github/jitwxs/easydata/core/convert/MapEntryConvert.java
@@ -6,7 +6,6 @@ import io.github.jitwxs.easydata.common.exception.EasyDataConvertException;
 import lombok.extern.slf4j.Slf4j;
 import org.powermock.reflect.Whitebox;
 
-import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -35,18 +34,12 @@ public class MapEntryConvert implements IConvert<Map.Entry> {
         }
 
         try {
-            final Method method = Whitebox.getMethod(target, "of", Map.Entry.class);
-            if (method != null) {
-                return Whitebox.invokeMethod(target, method, entry);
-            }
+            return Whitebox.invokeMethod(target, "of", entry);
         } catch (Exception ignored) {
         }
 
         try {
-            final Method method = Whitebox.getMethod(target, "of", Object.class, Object.class);
-            if (method != null) {
-                return Whitebox.invokeMethod(target, method, entry.getKey(), entry.getValue());
-            }
+            return Whitebox.invokeMethod(target, "of", entry.getKey(), entry.getValue());
         } catch (Exception ignored) {
         }
 

--- a/easydata/src/main/java/io/github/jitwxs/easydata/core/convert/MapEntryConvert.java
+++ b/easydata/src/main/java/io/github/jitwxs/easydata/core/convert/MapEntryConvert.java
@@ -3,6 +3,7 @@ package io.github.jitwxs.easydata.core.convert;
 import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.JSONObject;
 import io.github.jitwxs.easydata.common.exception.EasyDataConvertException;
+import io.github.jitwxs.easydata.common.util.CollectionUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.powermock.reflect.Whitebox;
 
@@ -49,13 +50,13 @@ public class MapEntryConvert implements IConvert<Map.Entry> {
     private Map.Entry fromString(final String string) {
         final JSONObject jsonObject = JSON.parseObject(string);
 
-        final String key = jsonObject.keySet().iterator().next();
+        final String key = CollectionUtils.randomElement(jsonObject.keySet());
         final String value = jsonObject.getString(key);
 
         final HashMap<String, String> map = new HashMap<String, String>() {{
             put(key, value);
         }};
 
-        return map.entrySet().iterator().next();
+        return CollectionUtils.randomElement(map.entrySet());
     }
 }

--- a/easydata/src/main/java/io/github/jitwxs/easydata/core/convert/MapEntryConvert.java
+++ b/easydata/src/main/java/io/github/jitwxs/easydata/core/convert/MapEntryConvert.java
@@ -1,0 +1,68 @@
+package io.github.jitwxs.easydata.core.convert;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.JSONObject;
+import io.github.jitwxs.easydata.common.exception.EasyDataConvertException;
+import lombok.extern.slf4j.Slf4j;
+import org.powermock.reflect.Whitebox;
+
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author jitwxs@foxmail.com
+ * @since 2022-05-26 22:19
+ */
+@Slf4j
+public class MapEntryConvert implements IConvert<Map.Entry> {
+    @Override
+    public Map.Entry convert(Object source) throws EasyDataConvertException {
+        throw new EasyDataConvertException("Not support operation");
+    }
+
+    @Override
+    public Map.Entry convert(Object source, Class<?> target) throws EasyDataConvertException {
+        final Class<?> sourceClass = source.getClass();
+
+        final Map.Entry entry;
+        if (sourceClass == String.class) {
+            entry = fromString((String) source);
+        } else if (Map.Entry.class.isAssignableFrom(sourceClass)) {
+            entry = (Map.Entry) source;
+        } else {
+            throw new EasyDataConvertException("Not support convert source class: " + sourceClass);
+        }
+
+        try {
+            final Method method = Whitebox.getMethod(target, "of", Map.Entry.class);
+            if (method != null) {
+                return Whitebox.invokeMethod(target, method, entry);
+            }
+        } catch (Exception ignored) {
+        }
+
+        try {
+            final Method method = Whitebox.getMethod(target, "of", Object.class, Object.class);
+            if (method != null) {
+                return Whitebox.invokeMethod(target, method, entry.getKey(), entry.getValue());
+            }
+        } catch (Exception ignored) {
+        }
+
+        throw new EasyDataConvertException("Not support suit method to invoke convert");
+    }
+
+    private Map.Entry fromString(final String string) {
+        final JSONObject jsonObject = JSON.parseObject(string);
+
+        final String key = jsonObject.keySet().iterator().next();
+        final String value = jsonObject.getString(key);
+
+        final HashMap<String, String> map = new HashMap<String, String>() {{
+            put(key, value);
+        }};
+
+        return map.entrySet().iterator().next();
+    }
+}

--- a/easydata/src/main/java/io/github/jitwxs/easydata/core/convert/ObjectConvert.java
+++ b/easydata/src/main/java/io/github/jitwxs/easydata/core/convert/ObjectConvert.java
@@ -39,11 +39,11 @@ public class ObjectConvert implements IConvert<Object> {
 
             switch (ClassGroupEnum.delegate(target)) {
                 case PROTOBUF_MESSAGE:
-                    return ObjectUtils.createProtoMessage(target, fieldGeneratorFunc);
+                    return ObjectUtils.createProtoMessage(target, null, fieldGeneratorFunc);
                 case PROTOBUF_BUILDER:
-                    return ObjectUtils.createProtoBuilder(target, fieldGeneratorFunc);
+                    return ObjectUtils.createProtoBuilder(target, null, fieldGeneratorFunc);
                 case NATIVE:
-                    return ObjectUtils.createJava(target, field -> false, fieldGeneratorFunc);
+                    return ObjectUtils.createJava(target, field -> false, null, fieldGeneratorFunc);
                 default:
                     throw new UnsupportedOperationException();
             }

--- a/easydata/src/main/java/io/github/jitwxs/easydata/core/loader/LoadingSource.java
+++ b/easydata/src/main/java/io/github/jitwxs/easydata/core/loader/LoadingSource.java
@@ -12,7 +12,6 @@ import lombok.Getter;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.List;
-import java.util.Map;
 
 /**
  * @author jitwxs@foxmail.com
@@ -54,7 +53,7 @@ public abstract class LoadingSource<T> {
      * @param fieldValue 字段值
      * @param fieldName  字段名
      */
-    protected void fillingField(final Object object, final Object fieldValue, final String[] fieldName) {
+    public void fillingField(final Object object, final Object fieldValue, final String[] fieldName) {
         if (fieldName == null) {
             return;
         }

--- a/easydata/src/main/java/io/github/jitwxs/easydata/core/mock/mocker/implicit/ArrayMocker.java
+++ b/easydata/src/main/java/io/github/jitwxs/easydata/core/mock/mocker/implicit/ArrayMocker.java
@@ -1,6 +1,7 @@
 package io.github.jitwxs.easydata.core.mock.mocker.implicit;
 
 import io.github.jitwxs.easydata.common.bean.MockConfig;
+import io.github.jitwxs.easydata.common.util.CollectionUtils;
 import io.github.jitwxs.easydata.core.mock.mocker.BaseMocker;
 import io.github.jitwxs.easydata.core.mock.mocker.IMocker;
 import lombok.AllArgsConstructor;
@@ -49,8 +50,8 @@ public class ArrayMocker implements IMocker<Object> {
         GenericArrayType genericArrayType = (GenericArrayType) this.type;
         // 递归获取该数组的维数，以及最后的Class类型
         Map<Integer, Map<Class, Type[]>> map = map(mockConfig, genericArrayType, 0);
-        Entry<Integer, Map<Class, Type[]>> entry = map.entrySet().iterator().next();
-        Entry<Class, Type[]> baseEntry = entry.getValue().entrySet().iterator().next();
+        Entry<Integer, Map<Class, Type[]>> entry = CollectionUtils.randomElement(map.entrySet());
+        Entry<Class, Type[]> baseEntry = CollectionUtils.randomElement(entry.getValue().entrySet());
         int[] dimensions = new int[entry.getKey()];
         for (int index = 0; index < dimensions.length; index++) {
             dimensions[index] = mockConfig.nexSize();

--- a/easydata/src/main/java/io/github/jitwxs/easydata/core/mock/mocker/implicit/ClassMocker.java
+++ b/easydata/src/main/java/io/github/jitwxs/easydata/core/mock/mocker/implicit/ClassMocker.java
@@ -36,6 +36,8 @@ public class ClassMocker implements IMocker<Object> {
             mocker = new CollectionMocker(clazz, genericTypes[0]);
         } else if (clazz.isEnum()) {
             mocker = new EnumMocker<>(clazz);
+        } else if (Map.Entry.class.isAssignableFrom(clazz)) {
+            mocker = new MapEntryMocker(clazz, genericTypes);
         } else {
             mocker = explicitProvider.delegate(clazz);
             if (mocker == null) {

--- a/easydata/src/main/java/io/github/jitwxs/easydata/core/mock/mocker/implicit/MapEntryMocker.java
+++ b/easydata/src/main/java/io/github/jitwxs/easydata/core/mock/mocker/implicit/MapEntryMocker.java
@@ -1,0 +1,49 @@
+package io.github.jitwxs.easydata.core.mock.mocker.implicit;
+
+import io.github.jitwxs.easydata.common.bean.MockConfig;
+import io.github.jitwxs.easydata.core.mock.mocker.BaseMocker;
+import io.github.jitwxs.easydata.core.mock.mocker.IMocker;
+import io.github.jitwxs.easydata.provider.ConvertProvider;
+import io.github.jitwxs.easydata.provider.ProviderFactory;
+
+import java.lang.reflect.Type;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author jitwxs@foxmail.com
+ * @since 2022-05-26 21:55
+ */
+public class MapEntryMocker implements IMocker<Object> {
+    private final Class<?> target;
+
+    private final Type[] types;
+
+    public MapEntryMocker(Class<?> target, Type[] paramTypes) {
+        this.target = target;
+
+        this.types = new Type[2];
+
+        int i = 0;
+        for (; i < paramTypes.length; i++) {
+            this.types[i] = paramTypes[i];
+        }
+
+        while (i < this.types.length) {
+            this.types[i++] = String.class;
+        }
+    }
+
+    @Override
+    public Object mock(MockConfig mockConfig) {
+        final Map<Object, Object> map = new HashMap<Object, Object>() {{
+            put(new BaseMocker(types[0]).mock(mockConfig), new BaseMocker(types[1]).mock(mockConfig));
+        }};
+
+        final Map.Entry<Object, Object> result = map.entrySet().iterator().next();
+
+        final ConvertProvider provider = ProviderFactory.delegate(ConvertProvider.class);
+
+        return provider.convert(result, target);
+    }
+}

--- a/easydata/src/main/java/io/github/jitwxs/easydata/core/mock/mocker/implicit/MapEntryMocker.java
+++ b/easydata/src/main/java/io/github/jitwxs/easydata/core/mock/mocker/implicit/MapEntryMocker.java
@@ -1,6 +1,7 @@
 package io.github.jitwxs.easydata.core.mock.mocker.implicit;
 
 import io.github.jitwxs.easydata.common.bean.MockConfig;
+import io.github.jitwxs.easydata.common.util.CollectionUtils;
 import io.github.jitwxs.easydata.core.mock.mocker.BaseMocker;
 import io.github.jitwxs.easydata.core.mock.mocker.IMocker;
 import io.github.jitwxs.easydata.provider.ConvertProvider;
@@ -40,7 +41,7 @@ public class MapEntryMocker implements IMocker<Object> {
             put(new BaseMocker(types[0]).mock(mockConfig), new BaseMocker(types[1]).mock(mockConfig));
         }};
 
-        final Map.Entry<Object, Object> result = map.entrySet().iterator().next();
+        final Map.Entry<Object, Object> result = CollectionUtils.randomElement(map.entrySet());
 
         final ConvertProvider provider = ProviderFactory.delegate(ConvertProvider.class);
 

--- a/easydata/src/main/java/io/github/jitwxs/easydata/core/verify/comp/BigDecimalComp.java
+++ b/easydata/src/main/java/io/github/jitwxs/easydata/core/verify/comp/BigDecimalComp.java
@@ -1,6 +1,6 @@
 package io.github.jitwxs.easydata.core.verify.comp;
 
-import io.github.jitwxs.easydata.common.util.BigDecimalUtil;
+import io.github.jitwxs.easydata.common.util.BigDecimalUtils;
 
 import java.math.BigDecimal;
 
@@ -15,7 +15,7 @@ public class BigDecimalComp extends BaseComp<BigDecimal> {
     }
 
     protected BigDecimalComp(BigDecimal precisionConfig) {
-        super(BigDecimalUtil.zeroIfNull(precisionConfig));
+        super(BigDecimalUtils.zeroIfNull(precisionConfig));
     }
 
     @Override

--- a/easydata/src/main/java/io/github/jitwxs/easydata/fastjson/ExtraFieldResolve.java
+++ b/easydata/src/main/java/io/github/jitwxs/easydata/fastjson/ExtraFieldResolve.java
@@ -1,0 +1,62 @@
+package io.github.jitwxs.easydata.fastjson;
+
+import com.alibaba.fastjson.parser.deserializer.ExtraProcessor;
+import com.alibaba.fastjson.parser.deserializer.ExtraTypeProvider;
+import com.google.common.collect.BiMap;
+import io.github.jitwxs.easydata.common.bean.FieldProperty;
+import io.github.jitwxs.easydata.common.cache.PropertyCache;
+import io.github.jitwxs.easydata.core.loader.JsonLoadingSource;
+import lombok.Data;
+
+import java.lang.reflect.Type;
+
+@Data
+public class ExtraFieldResolve implements ExtraProcessor, ExtraTypeProvider {
+    private final Class<?> target;
+
+    private final BiMap<String, String> extraFiledMap;
+
+    private final BiMap<String, String> extraFiledMap2;
+
+    private final JsonLoadingSource loadingSource;
+
+    public ExtraFieldResolve(Class<?> target, BiMap<String, String> extraFiledMap, JsonLoadingSource loadingSource) {
+        this.target = target;
+        this.extraFiledMap = extraFiledMap;
+        this.extraFiledMap2 = extraFiledMap.inverse();
+        this.loadingSource = loadingSource;
+    }
+
+    @Override
+    public void processExtra(Object object, String key, Object value) {
+        String mappingField = extraFiledMap.get(key);
+        if (mappingField != null) {
+            loadingSource.fillingField(object, value, new String[]{mappingField});
+
+            extraFiledMap.remove(key);
+            return;
+        }
+
+        mappingField = extraFiledMap2.get(key);
+        if (mappingField != null) {
+            loadingSource.fillingField(object, value, new String[]{mappingField});
+
+            extraFiledMap2.remove(key);
+        }
+    }
+
+    @Override
+    public Type getExtraType(Object object, String key) {
+        final String mappingField = extraFiledMap.getOrDefault(key, extraFiledMap2.get(key));
+        if (mappingField == null) {
+            return null;
+        }
+
+        final FieldProperty property = PropertyCache.tryGet(target, mappingField);
+        if (property == null) {
+            return null;
+        }
+
+        return property.getType();
+    }
+}

--- a/easydata/src/test/java/io/github/jitwxs/easydata/core/mock/SpecialClassMockTest.java
+++ b/easydata/src/test/java/io/github/jitwxs/easydata/core/mock/SpecialClassMockTest.java
@@ -1,0 +1,27 @@
+package io.github.jitwxs.easydata.core.mock;
+
+import io.github.jitwxs.easydata.common.bean.IgnoreBean;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * @author jitwxs@foxmail.com
+ * @since 2022-05-26 21:26
+ */
+public class SpecialClassMockTest {
+    @Test
+    public void testMockPair() {
+        final Pair<String, String> stringPair = EasyMock.run(new TypeKit<Pair<String, String>>() {
+        });
+        assertNotNull(stringPair);
+
+        final Pair objectPair = EasyMock.run(Pair.class);
+        assertNotNull(objectPair);
+
+        final Pair<Integer, IgnoreBean> beanPair = EasyMock.run(new TypeKit<Pair<Integer, IgnoreBean>>() {
+        });
+        assertNotNull(beanPair);
+    }
+}


### PR DESCRIPTION
(1) Fix Bugs

- 使用 mock 时，现在默认忽略 `synthetic`, `static` 属性的字段，降低 mock 失败率
- 解决 mock 循环依赖导致 `StackOverflow` 的异常

(2) Features

- 代码引入 jacoco 覆盖率插件
- 新增对 kv pair 类型的 mock 支持，例如 `Map.Entry`, `Pair<K, V>` 等
